### PR TITLE
set secp256k1 version to 3.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "ndjson": "^2.0.0",
     "mathjs": "9.4.1",
     "pumpify": "^2.0.1",
-    "secp256k1": "^4.0.2",
+    "secp256k1": "^3.8.0",
     "secure-random": "^1.1.2",
     "sha256": "^0.2.0",
     "sm-crypto": "git+https://github.com/bianjieai/sm-crypto-js.git#main"


### PR DESCRIPTION
It is need to set secp256K1 to 3.x because the api [Secp256k1.sign] no longer exist in 4.x
4.x api as belows:
https://github.com/cryptocoinjs/secp256k1-node/blob/master/API.md
