### PR TITLE
Bugfix MsgSwapFeeToken

### DIFF
--- a/dist/src/types/token.js
+++ b/dist/src/types/token.js
@@ -325,7 +325,7 @@ var MsgSwapFeeToken = exports.MsgSwapFeeToken = /*#__PURE__*/function (_Msg6) {
     value: function getModel() {
       var msg = new (this.constructor.getModelClass())().setFeePaid(_helper.TxModelCreator.createCoinModel(this.value.fee_paid.denom, this.value.fee_paid.amount)).setSender(this.value.sender);
       if (this.value.recipient) {
-        msg.setRecipient(this.value.recipient);
+        msg.setReceiver(this.value.recipient);
       }
       return msg;
     }

--- a/src/types/token.ts
+++ b/src/types/token.ts
@@ -367,7 +367,8 @@ export class MsgSwapFeeToken extends Msg {
       .setFeePaid(TxModelCreator.createCoinModel(this.value.fee_paid.denom, this.value.fee_paid.amount))
       .setSender(this.value.sender);
     if (this.value.recipient) {
-      msg.setRecipient(this.value.recipient);
+      msg.setReceiver(this.value.recipient);
+
     }
     return msg;
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed `setRecipient` method to `setReceiver` for better clarity in the `MsgSwapFeeToken` class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->